### PR TITLE
bump yargs to latest (resolves prototype pollution vulnerability)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,7 +1043,7 @@
                 "proxy-agent": "6.3.0",
                 "tar-fs": "3.0.4",
                 "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.1"
+                "yargs": "17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
@@ -1601,15 +1601,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camelcase": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/cfb": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.0.8.tgz",
@@ -1712,7 +1703,7 @@
                 "object-to-arguments": "0.0.8",
                 "pipe-functions": "^1.3.0",
                 "strip-ansi": "^4.0.0",
-                "yargs-parser": "^7.0.0"
+                "yargs-parser": "^21.1.1"
             }
         },
         "node_modules/cliss/node_modules/ansi-regex": {
@@ -5239,9 +5230,9 @@
             }
         },
         "node_modules/yargs": {
-            "version": "17.7.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-            "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -5257,15 +5248,6 @@
             }
         },
         "node_modules/yargs-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-            "integrity": "sha512-WhzC+xgstid9MbVUktco/bf+KJG+Uu6vMX0LN1sLJvwmbCQVxb4D8LzogobonKycNasCZLdOzTAk1SK7+K7swg==",
-            "dev": true,
-            "dependencies": {
-                "camelcase": "^4.1.0"
-            }
-        },
-        "node_modules/yargs/node_modules/yargs-parser": {
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",


### PR DESCRIPTION
resolves a bunch of security warnings on compile

note that this vulnerability still exists in xlsx (brought in via convert-excel-to-json) though as noted in github advisory https://github.com/advisories/GHSA-4r6h-8v6p-xvw6 this vulnerability is primarily expolited through crafted xls files, whereas our data is not user-provided so maybe OK for now